### PR TITLE
Make the current form to a multi-step form with formik

### DIFF
--- a/src/components/FormModel/formInitialValues.js
+++ b/src/components/FormModel/formInitialValues.js
@@ -1,0 +1,21 @@
+import nftMinterFormModel from './nftMinterFormModel';
+
+const {
+  formField: {
+    nameOfNFT,
+    description,
+    blockchain,
+    image
+  }
+} = nftMinterFormModel;
+
+export default {
+  [nameOfNFT.name]: '',
+  [description.name]: '',
+  [blockchain.name]: '',
+  [image.name]: {
+    file: null,
+    src: null,
+    name: ""
+  },
+};

--- a/src/components/FormModel/nftMinterFormModel.js
+++ b/src/components/FormModel/nftMinterFormModel.js
@@ -1,0 +1,27 @@
+export default {
+    formId: 'nftMinterFormModel',
+    formField: {
+      nameOfNFT: {
+        name: 'nameOfNFT',
+        label: 'Name of NFT*',
+        requiredErrorMsg: 'Name of NFT is required'
+      },
+      description: {
+        name: 'description',
+        label: 'Description*',
+        requiredErrorMsg: 'NFT description is required'
+      },
+      blockchain: {
+        name: 'blockchain',
+        label: 'Blockchain*',
+        requiredErrorMsg: 'Selecting a Blockchain is required'
+      },
+      image: {
+        name: 'image',
+        label: 'Upload Image*',
+        requiredErrorMsg: 'Image is required',
+        invalidErrorMsg: 'File type not valid'
+      },
+    }
+  };
+  

--- a/src/components/FormModel/validationSchema.js
+++ b/src/components/FormModel/validationSchema.js
@@ -1,0 +1,51 @@
+import * as Yup from 'yup';
+import nftMinterFormModel from './nftMinterFormModel';
+
+const {
+    formField: {
+      nameOfNFT,
+      description,
+      blockchain,
+      image
+    }
+} = nftMinterFormModel;
+
+const SUPPORTED_FORMATS = [
+    "image/jpg",
+    "image/jpeg",
+    "image/gif",
+    "image/png"
+];
+  
+
+const FILE_SIZE = 10 * 1024 * 1024; // ~= 10 MB
+  
+
+export default [
+    Yup.object().shape({
+        [nameOfNFT.name]: Yup.string().required(`${nameOfNFT.requiredErrorMsg}`),
+        [description.name]: Yup.string().required(`${description.requiredErrorMsg}`),
+        [blockchain.name]: Yup.string()
+            .nullable()
+            .required(`${blockchain.requiredErrorMsg}`),
+      }),
+    Yup.object().shape({
+        [image.name]: Yup.mixed()
+            .required('You need an image.')
+            .test(
+              "isEmpty",
+              `${image.requiredErrorMsg}`,
+              (value) => value && value.file
+            )
+            .test(
+              "fileSize",
+              "File too large",
+              (value) => value && value.file && value.file.size <= FILE_SIZE
+            )
+            .test(
+              "fileFormat",
+              "Unsupported Format",
+              value => value.file && SUPPORTED_FORMATS.includes(value.file.type)
+            )
+    })
+]

--- a/src/components/FormSection/Forms/ImageForm.js
+++ b/src/components/FormSection/Forms/ImageForm.js
@@ -1,0 +1,35 @@
+
+
+export default function ImageForm(){
+    const [file, setFile] = useState('');
+
+    const handleFileUpload = (event) => {
+        const reader = new FileReader();
+        const file = event.target.files[0];
+        reader.onloadend = () => {
+            setFile(reader.result)
+        };
+        reader.readAsDataURL(file);
+    }
+
+
+    return (
+        <>
+            <input
+                id="picture"
+                name="picture"
+                type="file"
+                onChange={(event) => {
+                    const file = event.target.files[0];
+                    setFieldValue("image_name", file.name);
+                    setFieldValue("image_type", file.type);
+                    handleFileUpload(event);
+                }}
+                />
+            <ErrorMessage name="image_type" component="div" />
+            <br/>
+            {file && <img width="300" height="300" src={file} /> }
+            <br/>
+        </>
+    )
+}

--- a/src/components/FormSection/Forms/MetadataForm.js
+++ b/src/components/FormSection/Forms/MetadataForm.js
@@ -1,0 +1,31 @@
+
+
+export default function MetadataForm(props) {
+
+
+    return (
+        <>
+            <label htmlFor="name">Name of NFT</label>
+            <Field type="text" name="name" />
+            <ErrorMessage name="name" component="div" />
+            <br></br>
+            <label htmlFor="description">Give your NFT a Description</label>
+            <Field type="text" as="textarea" name="description" />
+            <ErrorMessage name="description" component="div" />
+            <br/>
+            <Field 
+                as="select"
+                name="blockchain"
+                id="select_blockchain"
+                placeholder="Select Blockchain"
+            >
+                <option value="">Select a Chain (Testnet only)</option>
+                <option value="Ethereum">Ethereum (Kovan)</option>
+                <option value="Avalanche">Avalanche (Fuji)</option>
+                <option value="Binance Chain">Binance Chain (Testnet)</option>
+                <option value="Polygon">Polygon (Mumbai)</option>
+            </Field>
+            <ErrorMessage name="blockchain" component="div" />
+        </>
+    )
+}

--- a/src/components/FormSection/form.js
+++ b/src/components/FormSection/form.js
@@ -1,103 +1,31 @@
-import React, { useState } from "react"
-import { DisplayFormState } from "components/FormSection/displayFormState"
+import React, { useState } from "react";
+import { DisplayFormState } from "components/FormSection/displayFormState";
+import formInitialValues from "components/FormModel/formInitialValues";
+import validationSchema from "components/FormModel/validationSchema";
 import { Formik, Form, Field, FieldArray, ErrorMessage } from 'formik';
-import * as Yup from 'yup';
-
-const validationSchema = Yup.object().shape({
-    name: Yup.string()
-        .min(3, 'Too Short!')
-        .max(200, 'Too Long!')
-        .required('An NFT needs a name'),
-    description: Yup.string()
-        .min(3, 'Too Short!')
-        .max(200, 'Too Long!')
-        .required('An NFT needs a description'),
-    blockchain: Yup.string()
-        .min(1, 'Please select a Blockchain to proceed')
-        .required('Please select a Blockchain to proceed'),
-    image_type: Yup.mixed()
-        .required('You need an image.')
-        .test(
-            "fileFormat",
-            "Unsupported Format",
-            value => value && SUPPORTED_FORMATS.includes(value)
-        )
-    
-  });
-
-const SUPPORTED_FORMATS = [
-    "image/jpg",
-    "image/jpeg",
-    "image/gif",
-    "image/png"
-  ];
 
 const FormSection = () => {
-    const [file, setFile] = useState('')
+    const [activeStep, setActiveStep] = useState(0);
 
-    const handleFileUpload = (event) => {
-        const reader = new FileReader();
-        const file = event.target.files[0];
-        reader.onloadend = () => {
-            setFile(reader.result)
-        };
-        reader.readAsDataURL(file);
-      }
+    const mintNFT = (values, setSubmitting) => {
+        setTimeout(() => {
+            alert(JSON.stringify(values, null, 2));
+            setSubmitting(false);
+            }, 400);
+    }
 
     return (
         <Formik
-            initialValues={{ name: '', description: '' , image_name: '', image_type: '', blockchain: ''}}
-            validationSchema={validationSchema}
-            validate={values => {
-                const errors = {};
-                return errors;
-            }}
+            initialValues={formInitialValues}
+            validationSchema={validationSchema[activeStep]}
             onSubmit={(values, { setSubmitting }) => {
-                setTimeout(() => {
-                alert(JSON.stringify(values, null, 2));
-                setSubmitting(false);
-                }, 400);
+                mintNFT(values, setSubmitting)
             }}
         >
         {({ errors, touched, values, isSubmitting, setFieldValue }) => (
             <Form>
-                <label htmlFor="name">Name of NFT</label>
-                <Field type="text" name="name" />
-                <ErrorMessage name="name" component="div" />
                 <br></br>
-                <label htmlFor="description">Give your NFT a Description</label>
-                <Field type="text" as="textarea" name="description" />
-                <ErrorMessage name="description" component="div" />
-                <br></br>
-                <input
-                id="picture"
-                name="picture"
-                type="file"
-                onChange={(event) => {
-                    const file = event.target.files[0];
-                    setFieldValue("image_name", file.name);
-                    setFieldValue("image_type", file.type);
-                    handleFileUpload(event);
-                }}
-                />
-                <ErrorMessage name="image_type" component="div" />
-                <br/>
-                {file && <img width="300" height="300" src={file} /> }
-                <br/>
-                <Field 
-                    as="select"
-                    name="blockchain"
-                    id="select_blockchain"
-                    placeholder="Select Blockchain"
-                >
-                    <option value="">Select a Chain (Testnet only)</option>
-                    <option value="Ethereum">Ethereum (Kovan)</option>
-                    <option value="Avalanche">Avalanche (Fuji)</option>
-                    <option value="Binance Chain">Binance Chain (Testnet)</option>
-                    <option value="Polygon">Polygon (Mumbai)</option>
-                </Field>
-                <ErrorMessage name="blockchain" component="div" />
-                <br/>
+                
                 <button type="submit" disabled={isSubmitting}>
                     Mint NFT
                 </button>


### PR DESCRIPTION
I came to the conclusion, that I need to provide little guidance to the user with the different input fields, one can only mint an NFT once name and description are available and the image is uploaded to IPFS and a link to that image on IPFS is returned. (Complete metadata).
I was looking for a multistep form and found one, that is a good starting point (https://github.com/nphivu414/react-multi-step-form). This repo: https://github.com/yvesbou/multi-step-form is my clone where I try to distill the things I need from this multi-step-form. Have a look there.

The user experience will be approx. like this (Step 1 to 3)

1. User can fill out metadata fields (only name, description atm) and choose network
2. Image is set from file upload 
     1. user selects image
     2. user clicks button to upload to IPFS
3. User sees preview of metadata and can mint their NFT (We use a boilerplate NFT smart contract and deploy it to all chains and use those)